### PR TITLE
changed digitalOutput raster time to 1us in checkTiming

### DIFF
--- a/matlab/+mr/checkTiming.m
+++ b/matlab/+mr/checkTiming.m
@@ -27,7 +27,7 @@ function [ is_ok, text_error, total_dur ] = checkTiming( system, varargin )
             % we actually cannot check extensons anyway...
             continue;
         end
-        if isfield(e, 'type') && (strcmp(e.type,'adc') || strcmp(e.type,'rf'))
+        if isfield(e, 'type') && (strcmp(e.type,'adc') || strcmp(e.type,'rf') || strcmp(e.type,'output'))
             raster=system.rfRasterTime;
         else
             raster=system.gradRasterTime;


### PR DESCRIPTION
The current version of checkTiming will complain if digitalOutput (e.g. ext trigger) is not aligned to gradient raster time. At least on Siemens systems it can be switched with RF raster time, so I changed how it is treated.