### PR TITLE
Small fix for python calls from Matlab

### DIFF
--- a/matlab/+mr/makeAdiabaticPulse.m
+++ b/matlab/+mr/makeAdiabaticPulse.m
@@ -97,7 +97,7 @@ if ~isempty(opt.pythonCmd)
     if status~=0
         error(['provided python executable ''' opt.pythonCmd ''' returns an error on the version check']);
     end
-    python='python';
+    python=opt.pythonCmd;
 elseif ispc()
     % on Windows we rely on the PATH settings
     [status, result]=system('python --version');

--- a/matlab/+mr/makeSLRpulse.m
+++ b/matlab/+mr/makeSLRpulse.m
@@ -76,7 +76,7 @@ if ~isempty(opt.pythonCmd)
     if status~=0
         error(['provided python executable ''' opt.pythonCmd ''' returns an error on the version check']);
     end
-    python='python';
+    python=opt.pythonCmd;
 elseif ispc()
     % on Windows we rely on the PATH settings
     [status, result]=system('python --version');


### PR DESCRIPTION
I just noticed that the python entrypoint command is not assigned correctly when error condition is bypassed in `makeSLRPulse.m` and `makeAdiabaticPulse.m`. 

I pushed a small fix, which solved the problem for me. 

Thanks! 