### PR TITLE
fix testReport() so it also works when there are noise scans

### DIFF
--- a/matlab/+mr/@Sequence/testReport.m
+++ b/matlab/+mr/@Sequence/testReport.m
@@ -38,6 +38,9 @@ flipAnglesDeg=unique(flipAnglesDeg);
 %[ktraj_adc, t_adc, ktraj, t_ktraj, t_excitation, t_refocusing] = obj.calculateKspacePP();
 [ktraj_adc, t_adc, ~, ~, t_excitation, ~] = obj.calculateKspacePP('externalWaveformsAndTimes',wnt);
 
+% remove all ADC events that come before the first RF event (noise scans or alike)
+t_adc = t_adc(t_adc > t_excitation(1));
+
 % trajectory calculation will fail for spin-echoes if seq is loaded from a 
 % file for the current file format revision (1.2.0) because we do not store 
 % the use of the RF pulses. Read function has an option 'detectRFuse' which


### PR DESCRIPTION
Hi,

whenever I add a noise scan to my sequence, test.seqReport() breaks before the first RF event is after the first ADC event.

This example code here demonstrates the issue:

```matlab
% This sequence displays an issue with seq.testReport(). It is not a very
% good sequence.
seq=mr.Sequence();
% create rf and adc event
adc = mr.makeAdc(128,'Duration',512e-6);
rf = mr.makeBlockPulse(pi/8,'Duration',1e-3);

% add a noise scan
seq.addBlock(mr.makeLabel('SET','NOISE',true));
seq.addBlock(adc)
seq.addBlock(mr.makeLabel('SET','NOISE',false));

seq.addBlock(rf);
seq.addBlock(adc);
r = seq.testReport();
for i=1:size(r,2)
    disp(r{i});
end
```
output:
```
Array indices must be positive integers or logical values.

Error in mr.Sequence/testReport (line 75)
    TE=t_echo-t_ex_tmp(end);

Error in untitled3 (line 15)
r = seq.testReport();
```

My suggested edit fixes the issue and testReport() now works both for this minimal example and for a realistic sequence.

Best,
Dario