### PR TITLE
add test suite for rotation extension.

### DIFF
--- a/matlab/+mr/makeRotation.m
+++ b/matlab/+mr/makeRotation.m
@@ -8,7 +8,7 @@ function rot = makeRotation( varargin )
 if nargin<1
     error('makeRotation:invalidArguments','Must supply rotation angle(s)');
 end
-switch length(varargin{1})
+switch numel(varargin{1})
     case 1
         phi = varargin{1};
         if nargin<2
@@ -34,7 +34,7 @@ switch length(varargin{1})
     case 4
         rot.rotQuaternion=mr.aux.quat.normalize(varargin{1});
     case 9
-        assert(size(varargin{1})==[3 3]);
+        assert(all(size(varargin{1})==[3 3]));
         rot.rotQuaternion=mr.aux.quat.fromRotMat(varargin{1});
     otherwise
         error('unexpected input to makeRotation');

--- a/tests/expected_output/seq_make_radial.seq
+++ b/tests/expected_output/seq_make_radial.seq
@@ -1,0 +1,88 @@
+# Pulseq sequence file
+# Created by MATLAB mr toolbox
+
+[VERSION]
+major 1
+minor 5
+revision 1
+
+[DEFINITIONS]
+AdcRasterTime 1e-07 
+BlockDurationRaster 1e-05 
+GradientRasterTime 1e-05 
+RadiofrequencyRasterTime 1e-06 
+
+# Format of blocks:
+# NUM DUR RF  GX  GY  GZ  ADC  EXT
+[BLOCKS]
+ 1 100   1   0   0   0  0  0
+ 2  83   0   1   0   0  0  1
+ 3 100   1   0   0   0  0  0
+ 4  83   0   1   0   0  0  2
+ 5 100   1   0   0   0  0  0
+ 6  83   0   1   0   0  0  3
+ 7 100   1   0   0   0  0  0
+ 8  83   0   1   0   0  0  4
+ 9 100   1   0   0   0  0  0
+10  83   0   1   0   0  0  5
+11 100   1   0   0   0  0  0
+12  83   0   1   0   0  0  1
+
+# Format of RF events:
+# id ampl. mag_id phase_id time_shape_id center delay freqPPM phasePPM freq phase use
+# ..   Hz      ..       ..            ..     us    us     ppm  rad/MHz   Hz   rad  ..
+# Field 'use' is the initial of: excitation refocusing inversion saturation preparation other undefined
+[RF]
+1          250 1 2 3 500 0 0 0 0 0 u
+
+# Format of trapezoid gradients:
+# id amplitude rise flat fall delay
+# ..      Hz/m   us   us   us    us
+[TRAP]
+ 1  1.69492e+06 240  350 240   0
+
+# Format of extension lists:
+# id type ref next_id
+# next_id of 0 terminates the list
+# Extension list is followed by extension specifications
+[EXTENSIONS]
+1 1 1 0
+2 1 2 0
+3 1 3 0
+4 1 4 0
+5 1 5 0
+
+# Extension specification for rotation events:
+# id RotQuat0 RotQuatX RotQuatY RotQuatZ
+extension ROTATIONS 1
+1  1 0 0 0
+2  0.965926 0 0 0.258819
+3  0.92388 0 0 0.382683
+4  0.866025 0 0 0.5
+5  0.707107 0 0 0.707107
+
+# Sequence Shapes
+[SHAPES]
+
+shape_id 1
+num_samples 2
+1
+1
+
+shape_id 2
+num_samples 2
+0
+0
+
+shape_id 3
+num_samples 2
+0
+1000
+
+
+[SIGNATURE]
+# This is the hash of the Pulseq file, calculated right before the [SIGNATURE] section was added
+# It can be reproduced/verified with md5sum if the file trimmed to the position right above [SIGNATURE]
+# The new line character preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away for recalculating/verification)
+Type md5
+Hash 40f73923926bba68c9c8c7e7d52733cb

--- a/tests/testBlock.m
+++ b/tests/testBlock.m
@@ -35,6 +35,20 @@ function verifyErrorThrown(testCase, funcHandle)
     testCase.verifyTrue(didError, 'Expected an error, but none was thrown.');
 end
 
+%% Helper functions to create rotation matrix
+function R = rotmat()
+    % ROTATION_MATRIX Create a 3x3 rotation matrix for a given angle (degrees)
+    theta = deg2rad(90.0);
+    R0 = [cos(theta), -sin(theta), 0];
+    R1 = [sin(theta),  cos(theta), 0];
+    R2 = [0, 0, 1];
+    R = mr.makeRotation([R0; R1; R2]);
+end
+
+function ID = identity()
+    ID = mr.makeRotation(eye(3));
+end
+
 %% Tests for gradient continuity in addBlock
 function testGradientContinuity1(testCase)
     % Trap followed by extended gradient: No error
@@ -83,3 +97,75 @@ function testGradientContinuity7(testCase)
     seq.addBlock(testCase.TestData.gx_endshigh);
     verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh2));
 end
+
+%% Tests for gradient continuity in addBlock when blocks are rotated
+function testGradientContinuityRot1(testCase)
+    % Trap followed by extended gradient: No error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_trap, identity());
+    seq.addBlock(testCase.TestData.gx_extended, identity());
+    seq.addBlock(testCase.TestData.gx_trap, identity());
+end
+
+function testGradientContinuityRot2(testCase)
+    % Trap followed by non-zero gradient: Should raise an error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_trap, identity());
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh, identity()));
+end
+
+function testGradientContinuityRot3(testCase)
+    % Gradient starts at non-zero in first block: Should raise an error
+    seq = mr.Sequence();
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh, identity()));
+end
+
+function testGradientContinuityRot4(testCase)
+    % Gradient starts and ends at non-zero: Should raise an error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.delay);
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_allhigh, identity()));
+end
+
+function testGradientContinuityRot5(testCase)
+    % Gradient starts at zero and has a delay: No error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_extended_delay, identity());
+end
+
+function testGradientContinuityRot6(testCase)
+    % Gradient starts at non-zero in other blocks: Should raise an error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.delay);
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh, identity()));
+end
+
+function testGradientContinuityRot7(testCase)
+    % Non-zero, but non-connecting gradients: Should raise an error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_endshigh, identity());
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh2, identity()));
+end
+
+function testGradientContinuityRot8(testCase)
+    % Non-zero, both gradients are rotated by the same angle: No error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_endshigh, rotmat());
+    seq.addBlock(testCase.TestData.gx_startshigh, rotmat());
+end
+
+function testGradientContinuityRot9(testCase)
+    % Non-zero, new gradient has different rotation from previous: Should raise an error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_endshigh, identity());
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh, rotmat()));
+end
+
+function testGradientContinuityRot10(testCase)
+    % Non-zero, new gradient has different rotation from previous: Should raise an error
+    seq = mr.Sequence();
+    seq.addBlock(testCase.TestData.gx_endshigh, rotmat());
+    verifyErrorThrown(testCase, @() seq.addBlock(testCase.TestData.gx_startshigh, identity()));
+end
+
+

--- a/tests/testRotationExtension.m
+++ b/tests/testRotationExtension.m
@@ -1,0 +1,258 @@
+classdef testRotationExtension < matlab.unittest.TestCase
+    % testRotationExtension
+    %   This class implements tests for a radial sequence, its rotations,
+    %   write/read, plotting, and recreation. It is a 1–1 translation of your
+    %   Python test suite.
+    
+    properties (Constant)
+        % Expected output directory (relative to this file)
+        expectedOutputPath = fullfile(fileparts(mfilename('fullpath')), 'expected_output');
+    end
+    
+    methods (Test)
+        
+        function test_vs_rotate(testCase)
+            % Test that explicit gradient rotation (via pp.rotate) yields the same results
+            % as the version using rotation extensions.
+            seq  = seq_make_radial();
+            seq2 = seq_make_radial_norotext();
+            
+            % Test waveforms_and_times (assumed to return cell arrays of cells)
+            grads1 = seq.waveforms_and_times();
+            grads2 = seq2.waveforms_and_times();
+            channels = {'x', 'y', 'z'};
+            for ch = 1:length(channels)
+                if isempty(grads1{ch}) && isempty(grads2{ch})
+                    continue;
+                end
+                verifyApproxEqual(testCase, grads1{ch}(1, :), grads2{ch}(1, :), 1e-5, 1e-5, ...
+                    sprintf('Time axis of gradient waveform for channel %s does not match', channels{ch}));
+                verifyApproxEqual(testCase, grads1{ch}(2, :), grads2{ch}(2, :), 1e2, 1e-3, ...
+                    sprintf('Gradient values of gradient waveform for channel %s do not match', channels{ch}));
+            end
+                       
+             % Test approximate equality of k-space calculation.
+            kspace1 = seq.calculateKspacePP();
+            kspace2 = seq2.calculateKspacePP();
+            verifyApproxEqual(testCase, kspace2, kspace1, 1e-1, []);
+        end
+        
+        function test_sequence_save_expected(testCase)
+            % When the SAVE_EXPECTED environment variable is set,
+            % write the sequence file to the expected output directory.
+            if isempty(getenv('SAVE_EXPECTED'))
+                testCase.assumeFail('SAVE_EXPECTED not set; skipping saving expected sequence files.');
+            end
+            seq = seq_make_radial();
+            filename = fullfile(testRotationExtension.expectedOutputPath, 'seq_make_radial.seq');
+            seq.write(filename);
+            % (Additional verification could be added here.)
+        end
+        
+        function test_plot(testCase)
+            % Test that the sequence can be plotted without errors.
+            seq = seq_make_radial();
+            try
+                seq.plot();
+                seq.plot('showBlocks', true);
+                seq.plot('timeRange', [0, 1e-3]);
+                seq.plot('timeDisp', 'ms');
+                close all;
+            catch ME
+                testCase.verifyFail(['Plotting failed: ', ME.message]);
+            end
+        end
+        
+        function test_writeread(testCase)
+            % Test that writing a sequence to file and reading it back
+            % produces an equivalent sequence.
+            tempFile = fullfile(tempdir, 'seq_make_radial.seq');
+            seq = seq_make_radial();
+            
+            % Write sequence to file
+            seq.write(tempFile);
+            
+            % Read written sequence back in
+            seq2 = mr.Sequence();  % New sequence with same system settings.
+            seq2.read(tempFile);
+            
+            % Compare sequence block events (using field names as keys).
+            testCase.verifyEqual(length(seq.blockEvents), length(seq2.blockEvents), ...
+                'Sequence block IDs are not identical');
+            
+            for i = 1:length(seq.blockEvents)
+                block_orig = seq.getBlock(i);
+                block_compare = seq2.getBlock(i);
+                
+                % If block contains rf.use, set it to 'undefined'
+                if isfield(block_orig, 'rf') && isfield(block_orig.rf, 'use')
+                    block_orig.rf.use = 'undefined';
+                end
+                
+                verifyApproxEqual(testCase, block_compare, block_orig, 1e-5, 1e-5);
+            end
+            
+            % Compare gradient waveforms.
+            grads1 = seq.waveforms_and_times();
+            grads2 = seq2.waveforms_and_times();
+            channels = {'x', 'y', 'z'};
+            for ch = 1:length(channels)
+                if isempty(grads1{ch}) && isempty(grads2{ch})
+                    continue;
+                end
+                verifyApproxEqual(testCase, grads1{ch}(1, :), grads2{ch}(1, :), 1e-5, 1e-5, ...
+                    sprintf('Time axis of gradient waveform for channel %s does not match', channels{ch}));
+                verifyApproxEqual(testCase, grads1{ch}(2, :), grads2{ch}(2, :), 1e2, 1e-3, ...
+                    sprintf('Gradient values of gradient waveform for channel %s do not match', channels{ch}));
+            end
+            
+            % Restore RF use for k-space calculation.
+            for i = 1:length(seq.blockEvents)
+                block_orig = seq.getBlock(i);
+                if isfield(block_orig, 'rf') && isfield(block_orig.rf, 'use')
+                    block_compare = seq2.getBlock(i);
+                    block_compare.rf.use = block_orig.rf.use;
+                end
+            end
+            
+            % Test approximate equality of k-space calculation.
+            kspace1 = seq.calculateKspacePP();
+            kspace2 = seq2.calculateKspacePP();
+            verifyApproxEqual(testCase, kspace2, kspace1, 1e-1, []);
+            
+            % Test whether labels are the same.
+            labels_seq = seq.evalLabels('evolution', 'blocks');
+            labels_seq2 = seq2.evalLabels('evolution', 'blocks');
+            testCase.verifyEqual(fieldnames(labels_seq), fieldnames(labels_seq2), 'Sequences do not contain the same set of labels');
+            label_keys = fieldnames(labels_seq);
+            for i = 1:length(label_keys)
+                key = label_keys{i};
+                testCase.verifyEqual(labels_seq.(key), labels_seq2.(key), ...
+                    sprintf('Label %s does not match', key));
+            end
+            
+            if exist(tempFile, 'file')
+                delete(tempFile);
+            end
+        end
+        
+        function test_recreate(testCase)
+            % Test that recreating a sequence by extracting its blocks and re‑adding them
+            % to a new sequence yields an equivalent sequence.
+            seq = seq_make_radial();
+            seq2 = mr.Sequence();
+            for i = 1:length(seq.blockEvents)
+                seq2.addBlock(seq.getBlock(i));
+            end
+            for i = 1:length(seq.blockEvents)
+                verifyApproxEqual(testCase, seq2.getBlock(i), seq.getBlock(i), 1e-9, 1e-9, ...
+                    sprintf('Block %s does not match', i));
+            end
+            
+            % Compare gradient waveforms.
+            grads1 = seq.waveforms_and_times();
+            grads2 = seq2.waveforms_and_times();
+            channels = {'x','y','z'};
+            for ch = 1:length(channels)
+                if isempty(grads1{ch}) && isempty(grads2{ch})
+                    continue;
+                end
+                verifyApproxEqual(testCase, grads1{ch}(1, :), grads2{ch}(1, :), 1e-9, 1e-9, ...
+                    sprintf('Time axis of gradient waveform for channel %s does not match', channels{ch}));
+                verifyApproxEqual(testCase, grads1{ch}(2, :), grads2{ch}(2, :), 1e-9, 1e-9, ...
+                    sprintf('Gradient values of gradient waveform for channel %s do not match', channels{ch}));
+            end
+            
+            verifyApproxEqual(testCase, seq2.calculateKspacePP(), seq.calculateKspacePP(), 1e-6, []);
+            
+            labels_seq = seq.evalLabels('evolution', 'blocks');
+            labels_seq2 = seq2.evalLabels('evolution', 'blocks');
+            testCase.verifyEqual(fieldnames(labels_seq), fieldnames(labels_seq2), 'Sequences do not contain the same set of labels');
+            label_keys = fieldnames(labels_seq);
+            for i = 1:length(label_keys)
+                key = label_keys{i};
+                testCase.verifyEqual(labels_seq.(key), labels_seq2.(key), ...
+                    sprintf('Label %s does not match', key));
+            end
+        end
+    end
+end
+
+function R = rotation_matrix(angle)
+    % ROTATION_MATRIX Create a 3x3 rotation matrix for a given angle (degrees)
+    theta = deg2rad(angle);
+    R0 = [cos(theta), -sin(theta), 0];
+    R1 = [sin(theta),  cos(theta), 0];
+    R2 = [0, 0, 1];
+    R = [R0; R1; R2];
+end
+
+function seq = seq_make_radial()
+    % SEQ_MAKE_RADIAL creates a basic radial sequence.
+    seq = mr.Sequence();
+    rf = mr.makeBlockPulse(pi/2, 'duration', 1e-3);
+    gread = mr.makeTrapezoid('x', 'area', 1000);
+    theta = [0, 30, 45, 60, 90];
+    rot = cell(1, numel(theta));
+    for n = 1:numel(theta)
+        rot{n} = rotation_matrix(theta(n));
+    end
+    for n = 1:numel(theta)
+        seq.addBlock(rf);
+        seq.addBlock(gread, mr.makeRotation(rot{n}));
+    end
+    seq.addBlock(rf);
+    seq.addBlock(gread, mr.makeRotation(rot{1}));
+end
+
+function seq = seq_make_radial_norotext()
+    % SEQ_MAKE_RADIAL_NOROTEXT creates a radial sequence using explicit rotation
+    % via the pp.rotate function.
+    seq = mr.Sequence();
+    rf = mr.makeBlockPulse(pi/2, 'duration', 1e-3);
+    gread = mr.makeTrapezoid('x', 'area', 1000);
+    
+    theta = [0, 30, 45, 60, 90];
+    theta_rad = deg2rad(theta);
+    for n = 1:numel(theta_rad)
+        seq.addBlock(rf);
+        
+        args = mr.rotate('z', theta_rad(n), gread);
+        seq.addBlock(args{:});
+    end
+    seq.addBlock(rf);
+    
+    args = mr.rotate('z', theta_rad(1), gread);
+    seq.addBlock(args{:});
+end
+        
+%% --- Helper Function for Approximate Comparison ---
+function verifyApproxEqual(testCase, actual, expected, atol, rtol, varargin)
+    % Recursively verify approximate equality between actual and expected.
+    if isnumeric(actual) && isnumeric(expected)
+        if isempty(rtol)
+            testCase.verifyEqual(actual, expected, 'AbsTol', atol, varargin{:});
+        else
+            testCase.verifyEqual(actual, expected, 'AbsTol', atol, 'RelTol', rtol, varargin{:});
+        end
+    elseif isstruct(actual) && isstruct(expected)
+        f1 = sort(fieldnames(actual));
+        f2 = sort(fieldnames(expected));
+        testCase.verifyEqual(f1, f2, 'Structures have different fields.');
+        for i = 1:length(f1)
+            fld = f1{i};
+            verifyApproxEqual(testCase, actual.(fld), expected.(fld), atol, rtol, varargin{:});
+        end
+    elseif iscell(actual) && iscell(expected)
+        testCase.verifyEqual(numel(actual), numel(expected), 'Cell arrays differ in length.');
+        for i = 1:numel(actual)
+            verifyApproxEqual(testCase, actual{i}, expected{i}, atol, rtol, varargin{:});
+        end
+    else
+        if isempty(rtol)
+            testCase.verifyEqual(actual, expected, 'AbsTol', atol, varargin{:});
+        else
+            testCase.verifyEqual(actual, expected, 'AbsTol', atol, 'RelTol', rtol, varargin{:});
+        end
+    end
+end


### PR DESCRIPTION
This update the new test suite with tests for rotation extension (@m-a-x-i-m-z, @WSHoge, @jfnielsen). For now, it only test rotations provided as [3, 3] rotation matrix.

As expected, gradient check in testBlock.m fails to detect if new block has different rotation from previous, as gradient consistency right now does not read rotation extension from previous block.

The PR also fixes a bug when rotation is provided as [3, 3] rotation matrix.