### PR TITLE
Fix CalculatekspaceUnfunc with waveforms_and_times

### DIFF
--- a/matlab/+mr/@Sequence/Sequence.m
+++ b/matlab/+mr/@Sequence/Sequence.m
@@ -1481,8 +1481,17 @@ classdef Sequence < handle
             end
             
             % now calculate the actual k-space trajectory based on the
-            % gradient waveforms
-            gw=obj.gradient_waveforms();
+            % gradient waveforms (interp on grad raster time)
+            wave_data=obj.waveforms_and_times();
+            tmax=max([wave_data{1}(1,end) wave_data{2}(1,end) wave_data{3}(1,end)]);
+            dt=obj.gradRasterTime; % time raster
+            nt=ceil(tmax/dt);
+            %tmax=nt*dt;
+
+            gw=zeros(3,nt);
+            for i=1:3
+                gw(i,:)=interp1(wave_data{i}(1,:),wave_data{i}(2,:),((1:nt)-0.5)*dt,'linear',0);
+            end
             i_excitation=round(t_excitation/obj.gradRasterTime);
             i_refocusing=round(t_refocusing/obj.gradRasterTime);
 %             ii_next_excitation=min(length(i_excitation),1);
@@ -2807,3 +2816,4 @@ classdef Sequence < handle
         end
     end
 end % classdef
+


### PR DESCRIPTION
Function gradient_waveforms is deprecated.
Note: with this, calculateKspaceUnfunc is still faster than calculateKspacePP