### PR TITLE
Add Cambridge Pulseq testing notes

### DIFF
--- a/CAMBRIDGE_NOTES.md
+++ b/CAMBRIDGE_NOTES.md
@@ -1,0 +1,3 @@
+## Cambridge MRI Pulseq Testing Notes
+
+This fork is used to explore Pulseq sequence prototyping for MRI research and gradient trajectory development.


### PR DESCRIPTION
## Summary
Adds a short notes file for local Pulseq sequence prototyping and testing workflows.

## Changes
- add `CAMBRIDGE_NOTES.md`
- include a brief note on MRI research sequence prototyping
- document the purpose of this fork for local experimentation

## Motivation
This is intended as a lightweight documentation addition for personal and research-facing Pulseq testing workflows.

## Notes
No functional code changes were made.