### PR TITLE
Feat: allow getting raster edge arbitrary gradient samples with oversampling

### DIFF
--- a/src/ExternalSequence.cpp
+++ b/src/ExternalSequence.cpp
@@ -31,6 +31,7 @@ double SeqBlock::s_gradientRaster = 10.0;
 
 /***********************************************************/
 ExternalSequence::ExternalSequence()
+	: m_isArbGradCenterSampling(true)
 {
 	m_blocks.clear();	// probably not needed.
 	version_major=0;
@@ -1434,10 +1435,19 @@ bool ExternalSequence::decodeBlock(SeqBlock *block)
 				block->gradWaveforms[iC-GX] = std::vector<float>((waveform.size()+1)/2);
 				std::vector<float>::iterator it_os=waveform.begin();
 				for (std::vector<float>::iterator it=block->gradWaveforms[iC-GX].begin(); it !=block->gradWaveforms[iC-GX].end(); ++it){
-					*it=*it_os;
-					// std::advance(it_os,2); // this doen't work because of the odd number of elements 
-					++it_os;
-					if (it_os!=waveform.end())
+					if (m_isArbGradCenterSampling)
+					{
+						*it = *it_os;
+						// std::advance(it_os,2); // this doen't work because of the odd number of elements 
+						++it_os;
+					}
+					else
+					{
+						++it_os;
+						*it = *it_os;
+					}
+
+					if (it_os != waveform.end())
 						++it_os;
 				}
 			}

--- a/src/ExternalSequence.h
+++ b/src/ExternalSequence.h
@@ -896,6 +896,17 @@ class ExternalSequence
 	static void SetPrintFunction(PrintFunPtr fun);
 
 	/**
+	 * @brief Set arbitrary gradient sampling mode, only avaliable with oversampling samples  
+	 *
+	 * This will affect how we decode the arbitrary gradient samples with oversampling when calling decodeBlock().
+	 * If isArbGradCenterSampling is true, raster center samples of the arbitrary grads are stored,
+	 * otherswise we store the samples defined on the raster edge.
+	 *
+	 * @param  bool  If arbitrary gradient samples are defined on the raster center, true by default
+	 */
+	inline void SetArbGradCenterSampling(const bool arbGradCenterSampling) { m_isArbGradCenterSampling = arbGradCenterSampling; }
+
+	/**
 	 * @brief Lookup the custom definition
 	 *
 	 * Search the list of user-specified definitions through the [DEFINITIONS] section.
@@ -1101,6 +1112,7 @@ class ExternalSequence
 
 	std::map<std::string,int> m_fileIndex;     /**< @brief File location of sections, [RF], [ADC] etc */
 	std::set<int> m_fileSections;              /**< @brief File location of sections and EOF additionally */
+	bool m_isArbGradCenterSampling;            /**< @brief If expecting to get os arb grad raster center samples, true by default */
 
 	// Low level sequence blocks
 	std::vector<EventIDs> m_blocks;            /**< @brief List of sequence blocks */


### PR DESCRIPTION
## Background
In v1.5.0 pulseq, oversampling arbitrary gradients are stored in .seq files. The waveform is in the format of [center, edge, center, edge, ..., center, edge, center]. While in Pulseq C++ code, only samples in the center are stored in the gradient waveform vector. By default, the interpreter could only get the samples in the center, even if all the samples are stored in the .seq file.

## Features
Allow storing os arbitrary gradient samples on the raster edge when calling decodeBlock.

