### PR TITLE
Fix b1Unit input validator in mr.opts

### DIFF
--- a/matlab/+mr/opts.m
+++ b/matlab/+mr/opts.m
@@ -52,7 +52,7 @@ if isempty(parser)
     parser.addParamValue('slewUnit',validSlewUnits{1},...
         @(x) any(validatestring(x,validSlewUnits)));
     parser.addParamValue('b1Unit',validB1Units{1},...
-        @(x) any(validatestring(x,validSlewUnits)));
+        @(x) any(validatestring(x,validB1Units)));
     parser.addParamValue('maxGrad',[],@isnumeric);
     parser.addParamValue('maxSlew',[],@isnumeric);
     parser.addParamValue('maxB1',[],@isnumeric);


### PR DESCRIPTION
`mr.opts` registers the `b1Unit` name/value parameter with a validator that checks against `validSlewUnits` instead of `validB1Units`. As a result, any explicit `'b1Unit', value` call fails with a misleading error listing slew-rate units. The default `'Hz'` worked only because MATLAB's `inputParser` does not validate default values.

Did a quick test with MATLAB R2025a:

- Default behavior: `mr.opts()` returns struct
- mr.opts('maxB1', 20, 'b1Unit', 'uT') fails before fix
- mr.opts('maxB1', 20e-6, 'b1Unit', 'T') fails before fix
- After fix, both now returns struct