### PR TITLE
Proposal: inline documentation with structured help blocks (makeTrapezoid and makeAdc examples)

### DIFF
--- a/matlab/+mr/makeAdc.m
+++ b/matlab/+mr/makeAdc.m
@@ -1,20 +1,86 @@
 function adc=makeAdc(num,varargin)
-%makeAdc Create a ADC readout event.
-%   adc=makeAdc(n, 'Dwell', dwell) Create ADC with n samples
-%   with given dwell time.
+%makeAdc Create an ADC readout event.
 %
-%   adc=makeAdc(n, 'Duration', dur) Create ADC with n
-%   samples and specified total duration.
+%   PURPOSE
+%     Build an ADC (analog-to-digital converter) sampling event struct.
+%     The returned struct describes when sampling occurs, how many
+%     samples are acquired, and at what dwell rate, and is consumed by
+%     mr.Sequence/addBlock to add the readout to a sequence.
 %
-%   adc=makeAdc(..., 'Delay', d) Create ADC with initial delay.
+%   SIGNATURES
+%     adc = mr.makeAdc(numSamples, 'Duration', d)
+%     adc = mr.makeAdc(numSamples, 'Dwell', dt)
+%     adc = mr.makeAdc(numSamples, system, ...)              % system as 2nd positional arg
+%     adc = mr.makeAdc(numSamples, ..., 'system', system)    % system as name/value
+%     adc = mr.makeAdc(numSamples, ..., 'Delay', d)
 %
-%   adc=makeAdc(n, sys, ...) Create ADC considering system properties
-%   given in sys. For example, adcDeadTime can be taken into account by 
-%   making sure that both the before the ADC is as least as long as 
-%   adcDeadTime and another period of adcDeadTime is added after sampling 
-%   is finished. 
+%     Exactly one of 'Duration' or 'Dwell' must be supplied.
+%     If system is omitted, mr.opts() is used.
+%     Parameter names are case-insensitive.
 %
-%   See also  Sequence.addBlock
+%   INPUTS
+%     numSamples         integer  number of ADC samples (must be a whole number)  required
+%     system             struct   from mr.opts; defaults to mr.opts() if omitted  optional
+%     'Duration'         double   total acquisition duration, seconds. Dwell is
+%                                 computed as Duration/numSamples.                name/value
+%     'Dwell'            double   per-sample dwell time, seconds. Total acquisition
+%                                 time is Dwell*numSamples.                       name/value
+%     'Delay'            double   delay before sampling starts, seconds, default 0.
+%                                 Silently bumped to system.adcDeadTime if smaller
+%                                 (see NOTES).                                    name/value
+%     'freqOffset'       double   demodulation frequency offset, Hz, default 0    name/value
+%     'phaseOffset'      double   demodulation phase offset, radians, default 0   name/value
+%     'freqPPM'          double   frequency offset in PPM (relative to system B0
+%                                 and gamma), default 0                           name/value
+%     'phasePPM'         double   phase offset in PPM, default 0                  name/value
+%     'phaseModulation'  vector   per-sample phase modulation, length must equal
+%                                 numSamples. Default: [] (no modulation).        name/value
+%
+%   OUTPUT
+%     adc  struct with fields (in order returned by fieldnames):
+%       .type             char,    always 'adc'
+%       .numSamples       integer, number of samples (= input numSamples)
+%       .delay            double,  delay before sampling, seconds
+%                                  (>= system.adcDeadTime; see NOTES)
+%       .freqOffset       double,  Hz
+%       .phaseOffset      double,  radians
+%       .freqPPM          double,  PPM
+%       .phasePPM         double,  PPM
+%       .deadTime         double,  copy of system.adcDeadTime at construction, seconds
+%       .phaseModulation  double vector or []
+%       .dwell            double,  sample dwell time, seconds
+%                                  (= Duration/numSamples if Duration was given,
+%                                   else the supplied Dwell)
+%
+%   ERRORS
+%     - 'Either dwell or duration must be defined': both are 0, or both > 0.
+%       Exactly one must be specified.
+%     - 'ADC Phase modulation vector must have the same length as the number
+%       of samples': length(phaseModulation) ~= numSamples.
+%     - MATLAB:InputParser:* errors: numSamples is not an integer, or other
+%       validator failures (non-numeric where numeric is expected, etc.).
+%
+%   NOTES
+%     - The .delay field is silently increased to system.adcDeadTime if the
+%       requested delay is smaller. If you set 'Delay' to 0 with a nonzero
+%       system.adcDeadTime, the returned adc.delay will equal system.adcDeadTime,
+%       not 0. Account for this when computing block timing.
+%     - system.adcDeadTime is captured into adc.deadTime at construction time;
+%       changing system later does not retroactively update existing adc events.
+%     - Caches an inputParser in a persistent variable for performance;
+%       no other global state.
+%
+%   EXAMPLE
+%     sys = mr.opts('MaxGrad', 30, 'GradUnit', 'mT/m', ...
+%                   'MaxSlew', 170, 'SlewUnit', 'T/m/s', ...
+%                   'adcDeadTime', 20e-6);
+%     Nx = 256;  fov = 256e-3;  deltak = 1/fov;
+%     gx  = mr.makeTrapezoid('x', sys, 'FlatArea', Nx*deltak, 'FlatTime', 6.4e-3);
+%     % ADC sampled across the readout flat top
+%     adc = mr.makeAdc(Nx, sys, 'Duration', gx.flatTime, 'Delay', gx.riseTime);
+%
+%   SEE ALSO
+%     mr.opts, mr.makeTrapezoid, mr.Sequence/addBlock, mr.calcDuration
 
 persistent parser
 if isempty(parser)

--- a/matlab/+mr/makeTrapezoid.m
+++ b/matlab/+mr/makeTrapezoid.m
@@ -1,23 +1,90 @@
 function grad=makeTrapezoid(channel, varargin)
 %makeTrapezoid Create a trapezoid gradient event.
-%   g=makeTrapezoid(channel, ...) Create trapezoid gradient on
-%   the given channel.
 %
-%   g=makeTrapezoid(channel,lims,...) Create trapezoid with the specificed 
-%   gradient limits (e.g. amplitude, slew).
+%   PURPOSE
+%     Build a trapezoidal gradient event struct (rise / flat-top / fall)
+%     for a given logical channel. The returned struct is consumed by
+%     mr.Sequence/addBlock to add the gradient to a sequence.
 %
-%   g=makeTrapezoid(...,'Duration',d,'Area',a) Create a
-%   trapezoid gradient with given duration (s) and total area (1/m)
-%   including ramps.
+%   SIGNATURES
+%     g = mr.makeTrapezoid(channel, ...)                       % uses mr.opts() defaults
+%     g = mr.makeTrapezoid(channel, system, ...)               % system as 2nd positional arg
+%     g = mr.makeTrapezoid(channel, ..., 'system', system)     % system as name/value
+%     g = mr.makeTrapezoid(channel, ..., 'Duration', d, 'Area', a)
+%     g = mr.makeTrapezoid(channel, ..., 'FlatTime', ft, 'FlatArea', fa)
+%     g = mr.makeTrapezoid(channel, ..., 'FlatTime', ft, 'Amplitude', amp)
+%     g = mr.makeTrapezoid(channel, ..., 'Area', a)            % shortest possible timing
 %
-%   g=makeTrapezoid(...,'FlatTime',d,'FlatArea',a) Create a
-%   trapezoid gradient with given flat-top time and flat-top
-%   area not including ramps.
+%     Exactly one of 'Area', 'FlatArea', or 'Amplitude' must be supplied.
+%     Timing is determined by 'FlatTime' if given, else 'Duration' if given,
+%     else the shortest realizable timing for the requested 'Area'.
+%     Parameter names are case-insensitive.
 %
-%   g=makeTrapezoid(...,'Amplitude',a) Create a trapezoid gradient with
-%   given amplitude (Hz/m).
+%   INPUTS
+%     channel     char    'x'|'y'|'z'                                   required
+%     system      struct  from mr.opts; defaults to mr.opts() if omitted optional
+%     'Duration'  double  total duration including ramps, seconds, >0   name/value
+%     'Area'      double  total gradient area including ramps, 1/m      name/value
+%     'FlatTime'  double  flat-top duration, seconds                    name/value
+%     'FlatArea'  double  flat-top-only area, 1/m                       name/value
+%     'Amplitude' double  flat-top amplitude, Hz/m                      name/value
+%     'maxGrad'   double  override system.maxGrad, Hz/m                 name/value
+%     'maxSlew'   double  override system.maxSlew, Hz/m/s               name/value
+%     'riseTime'  double  force rise time, seconds                      name/value
+%     'fallTime'  double  force fall time, seconds (requires riseTime)  name/value
+%     'delay'     double  pre-event delay, seconds, default 0           name/value
 %
-%   See also  Sequence.addBlock  mr.opts
+%   OUTPUT
+%     grad  struct with fields:
+%       .type       char,    always 'trap' (includes degenerate triangle, flatTime=0)
+%       .channel    char,    'x'|'y'|'z'
+%       .amplitude  double,  flat-top amplitude, Hz/m
+%       .riseTime   double,  ramp-up duration, seconds
+%       .flatTime   double,  flat-top duration, seconds (0 for triangular)
+%       .fallTime   double,  ramp-down duration, seconds
+%       .area       double,  total area including ramps, 1/m
+%                            (= amplitude * (flatTime + riseTime/2 + fallTime/2))
+%       .flatArea   double,  flat-top-only area, 1/m  (= amplitude * flatTime)
+%       .delay      double,  pre-event delay, seconds
+%       .first      double,  gradient value at t=0,  Hz/m  (always 0 for trap)
+%       .last       double,  gradient value at end,  Hz/m  (always 0 for trap)
+%
+%   ERRORS
+%     makeTrapezoid:invalidArguments
+%       - 'fallTime' specified without 'riseTime'.
+%       - Not exactly one of 'Area' / 'FlatArea' / 'Amplitude' supplied.
+%       - 'FlatTime' supplied without 'FlatArea' or 'Amplitude'.
+%       - Neither 'Area' nor 'Duration' supplied.
+%     makeTrapezoid:invalidDuration
+%       - Requested area cannot be realized within the requested duration
+%         under maxGrad/maxSlew. Error message reports the minimum
+%         achievable duration in microseconds.
+%     makeTrapezoid:invalidAmplitude
+%       - Computed amplitude exceeds maxGrad.
+%     Assertion failure
+%       - With explicit riseTime+duration: duration < riseTime+fallTime,
+%         or computed amplitude exceeds maxGrad.
+%
+%   NOTES
+%     - All ramp/flat times are rounded up to system.gradRasterTime.
+%     - Internal storage uses Hz/m and Hz/m/s regardless of the units
+%       passed to mr.opts (mr.opts converts on input). Use mr.convert
+%       if you need physical units (mT/m, T/m/s, etc.).
+%     - Caches an inputParser in a persistent variable for performance;
+%       no other global state.
+%
+%   EXAMPLE
+%     sys = mr.opts('MaxGrad', 30, 'GradUnit', 'mT/m', ...
+%                   'MaxSlew', 170, 'SlewUnit', 'T/m/s');
+%     Nx = 256;  fov = 256e-3;  deltak = 1/fov;
+%     % Readout gradient with fixed flat-top area
+%     gx    = mr.makeTrapezoid('x', sys, 'FlatArea', Nx*deltak, 'FlatTime', 6.4e-3);
+%     % Matching prephaser: half the (negative) area of the readout
+%     gxPre = mr.makeTrapezoid('x', sys, 'Area', -gx.area/2, 'Duration', 1e-3);
+%
+%   SEE ALSO
+%     mr.opts, mr.makeExtendedTrapezoid, mr.makeArbitraryGrad,
+%     mr.calcDuration, mr.Sequence/addBlock
 
 persistent parser
 


### PR DESCRIPTION
This is a proposed change in a form of a PR to show what inline function help blocks can be changed to. As an example, I modified the comments in `matlab/+mr/makeTrapezoid.m` and `matlab/+mr/makeAdc.m`

The goals with this effort are:
- Increased descriptiveness and structure that can translate into a pulseq documentation page in the future
- Help block structure allows for easy future CI/CD if documentation is generated
- Friendly format for AI assistants. If users want to code with AI assistance --> structured, repeatable, and discoverable function usage allows current AI agents to work well with the pulseq package. Many AI assistants navigate and gather context through bash tooling, so a descriptive help block work well with AI.

Long term goal would be to document all (or at least vital) pulseq functions in this repeatable manner.

Curious if this work seems valuable, and if so, happy to discuss what format, sections, and preferences are for help blocks in .m files. Eventually, AI work can be integrated, or users can fork a more AI-friendly pulseq repo for their own work.

Note: no code changes....just documentation