### PR TITLE
Fix mode='lenghen' typo and string compare in mr.calcAdcSeg + tests/testCalcADCSegments.m typo correction

### DIFF
--- a/matlab/+mr/calcAdcSeg.m
+++ b/matlab/+mr/calcAdcSeg.m
@@ -18,13 +18,8 @@ if ~exist('mode', 'var')
     mode='shorten';
 end
 
-switch mode
-    case 'shorten'
-        iMode=-1;
-    case 'lenghen'
-        iMode=1;
-    otherwise
-        error('In mr.calcAdcSeg(...,mode) mode should be either ''shorten'' or ''lenghen''');
+if ~strcmp(mode,'shorten') && ~strcmp(mode,'lengthen')
+    error('In mr.calcAdcSeg(...,mode) mode should be either ''shorten'' or ''lengthen''');
 end
 
 t_eps=1e-9; % TODO: shift it to the system parameters???
@@ -44,10 +39,10 @@ if gcd_adcDiv~=system.adcSamplesDivisor
     samplesStep=samplesStep*system.adcSamplesDivisor/gcd_adcDiv;
 end
 
-if mode=='shorten'
-    numSamplesStepped=floor(numSamples/samplesStep); 
+if strcmp(mode,'shorten')
+    numSamplesStepped=floor(numSamples/samplesStep);
 else
-    numSamplesStepped=ceil(numSamples/samplesStep); 
+    numSamplesStepped=ceil(numSamples/samplesStep);
 end
 
 while numSamplesStepped>0 && numSamplesStepped<2*numSamples/samplesStep
@@ -71,7 +66,7 @@ while numSamplesStepped>0 && numSamplesStepped<2*numSamples/samplesStep
     if (adcSamplesPerSegment<=system.adcSamplesLimit && adcSegments<=128)
         break
     end
-    if mode=='shorten'
+    if strcmp(mode,'shorten')
         numSamplesStepped=numSamplesStepped-1; % try again with a smaller number of samples
     else
         numSamplesStepped=numSamplesStepped+1; % try again with a greater number of samples

--- a/tests/testCalcADCSegments.m
+++ b/tests/testCalcADCSegments.m
@@ -54,7 +54,7 @@ function testCalcADC(testCase)
         if modeNum == 1
             mode = 'shorten';
         else
-            mode = 'lenghen';
+            mode = 'lengthen';
         end
 
         % Update system settings


### PR DESCRIPTION
The mode argument was misspelled as 'lenghen' in both the switch case and the error message. The help comment mentions 'lengthen', which would not work.

Fixes:
- Rename 'lenghen' to 'lengthen' in validator and error message
- Replace switch+iMode with strcmp (iMode doesn't seem to be used anywhere)
- Replace `mode=='shorten'` with `strcmp` ---> "==" does element-wise comparison and returns a logical vector, not a scalar. So, the "==" won't work when `mode = 'lengthen'` with 8 chars
- Updated tests/testCalcADCSegments.m to pass 'lengthen'. I found no other references of 'lenghen'