### PR TITLE
Reject cross-category unit conversion with help text in mr.convert

### DIFF
--- a/matlab/+mr/convert.m
+++ b/matlab/+mr/convert.m
@@ -35,6 +35,22 @@ if isempty(opt.toUnit)
     end
 end
 
+% Verify fromUnit and toUnit are in the same category.
+if ismember(opt.fromUnit,validB1Units),       fromCat = 'B1';
+elseif ismember(opt.fromUnit,validGradUnits), fromCat = 'gradient';
+elseif ismember(opt.fromUnit,validSlewUnits), fromCat = 'slew rate';
+end
+
+if ismember(opt.toUnit,validB1Units),         toCat = 'B1';
+elseif ismember(opt.toUnit,validGradUnits),   toCat = 'gradient';
+elseif ismember(opt.toUnit,validSlewUnits),   toCat = 'slew rate';
+end
+
+if ~strcmp(fromCat,toCat)
+    error('mr.convert: fromUnit ''%s'' (%s) and toUnit ''%s'' (%s) are in different unit categories.', ...
+        opt.fromUnit, fromCat, opt.toUnit, toCat);
+end
+
 % Convert to standard units
 switch opt.fromUnit
     case {'Hz','Hz/m','Hz/m/s'}


### PR DESCRIPTION
`mr.convert` currently doesn't check if `fromUnit` and `toUnit` belong to the same [B1 / Grad / Slew] category. For example, I am able to successfully call:
> mr.convert(170, 'T/m/s', 'mT') 

With the proposed change, an error would now surface:
> mr.convert(170,'T/m/s', 'mT')
> Error using mr.convert (line 50)
> mr.convert: fromUnit 'T/m/s' (slew rate) and toUnit 'mT' (B1) are in different unit categories.

Since `mr.convert` is returning a double with no attached unit metadata, nothing is breaking if a cross-category conversion is performed. But, it might help out with debugging if someone accidentally mistypes something :-)