### PR TITLE
Reject factor==0 at makeSoftDelay construction

### DIFF
--- a/matlab/+mr/makeSoftDelay.m
+++ b/matlab/+mr/makeSoftDelay.m
@@ -33,6 +33,10 @@ if length(regexp(opt.hint, '(\s+)','split'))>1
     error('makeSoftDelay: parameter ''hint'' may not contain white space caharacters');
 end
 
+if opt.factor==0
+    error('makeSoftDelay: parameter ''factor'' must be nonzero');
+end
+
 sd.type   = 'softDelay';
 sd.num    = opt.numID;
 sd.hint   = opt.hint;

--- a/matlab/+mr/makeSoftDelay.m
+++ b/matlab/+mr/makeSoftDelay.m
@@ -30,7 +30,7 @@ parse(parser, varargin{:});
 opt = parser.Results;
 
 if length(regexp(opt.hint, '(\s+)','split'))>1
-    error('makeSoftDelay: parameter ''hint'' may not contain white space caharacters');
+    error('makeSoftDelay: parameter ''hint'' may not contain white space characters');
 end
 
 if opt.factor==0


### PR DESCRIPTION
factor==0 is already flagged by `seq.checkTiming()` later. Could save someone a headache to catch the error at the constructor where the fix is local, and error message can name the parameter directly.

My opinion -- still good idea to keep the additional check in `checkTiming` as a second line of defense. 

Also tiny typo fix