### PR TITLE
Retrofit help blocks to leading [kind] tag format

### DIFF
--- a/matlab/+mr/makeAdc.m
+++ b/matlab/+mr/makeAdc.m
@@ -19,22 +19,22 @@ function adc=makeAdc(num,varargin)
 %     Parameter names are case-insensitive.
 %
 %   INPUTS
-%     numSamples         integer  number of ADC samples (must be a whole number)  required
-%     system             struct   from mr.opts; defaults to mr.opts() if omitted  optional
-%     'Duration'         double   total acquisition duration, seconds. Dwell is
-%                                 computed as Duration/numSamples.                name/value
-%     'Dwell'            double   per-sample dwell time, seconds. Total acquisition
-%                                 time is Dwell*numSamples.                       name/value
-%     'Delay'            double   delay before sampling starts, seconds, default 0.
-%                                 Silently bumped to system.adcDeadTime if smaller
-%                                 (see NOTES).                                    name/value
-%     'freqOffset'       double   demodulation frequency offset, Hz, default 0    name/value
-%     'phaseOffset'      double   demodulation phase offset, radians, default 0   name/value
-%     'freqPPM'          double   frequency offset in PPM (relative to system B0
-%                                 and gamma), default 0                           name/value
-%     'phasePPM'         double   phase offset in PPM, default 0                  name/value
-%     'phaseModulation'  vector   per-sample phase modulation, length must equal
-%                                 numSamples. Default: [] (no modulation).        name/value
+%     numSamples         [required]    integer, number of ADC samples (must be a whole number)
+%     system             [optional]    struct from mr.opts; defaults to mr.opts() if omitted
+%     'Duration'         [name/value]  double, total acquisition duration, seconds. Dwell is
+%                                      computed as Duration/numSamples.
+%     'Dwell'            [name/value]  double, per-sample dwell time, seconds. Total
+%                                      acquisition time is Dwell*numSamples.
+%     'Delay'            [name/value]  double, delay before sampling starts, seconds,
+%                                      default 0. Silently bumped to system.adcDeadTime
+%                                      if smaller (see NOTES).
+%     'freqOffset'       [name/value]  double, demodulation frequency offset, Hz, default 0
+%     'phaseOffset'      [name/value]  double, demodulation phase offset, radians, default 0
+%     'freqPPM'          [name/value]  double, frequency offset in PPM (relative to system
+%                                      B0 and gamma), default 0
+%     'phasePPM'         [name/value]  double, phase offset in PPM, default 0
+%     'phaseModulation'  [name/value]  vector, per-sample phase modulation, length must
+%                                      equal numSamples. Default: [] (no modulation).
 %
 %   OUTPUT
 %     adc  struct with fields (in order returned by fieldnames):

--- a/matlab/+mr/makeTrapezoid.m
+++ b/matlab/+mr/makeTrapezoid.m
@@ -21,18 +21,18 @@ function grad=makeTrapezoid(channel, varargin)
 %     Parameter names are case-insensitive.
 %
 %   INPUTS
-%     channel     char    'x'|'y'|'z'                                   required
-%     system      struct  from mr.opts; defaults to mr.opts() if omitted optional
-%     'Duration'  double  total duration including ramps, seconds, >0   name/value
-%     'Area'      double  total gradient area including ramps, 1/m      name/value
-%     'FlatTime'  double  flat-top duration, seconds                    name/value
-%     'FlatArea'  double  flat-top-only area, 1/m                       name/value
-%     'Amplitude' double  flat-top amplitude, Hz/m                      name/value
-%     'maxGrad'   double  override system.maxGrad, Hz/m                 name/value
-%     'maxSlew'   double  override system.maxSlew, Hz/m/s               name/value
-%     'riseTime'  double  force rise time, seconds                      name/value
-%     'fallTime'  double  force fall time, seconds (requires riseTime)  name/value
-%     'delay'     double  pre-event delay, seconds, default 0           name/value
+%     channel      [required]    char, 'x'|'y'|'z'
+%     system       [optional]    struct from mr.opts; defaults to mr.opts() if omitted
+%     'Duration'   [name/value]  double, total duration including ramps, seconds, >0
+%     'Area'       [name/value]  double, total gradient area including ramps, 1/m
+%     'FlatTime'   [name/value]  double, flat-top duration, seconds
+%     'FlatArea'   [name/value]  double, flat-top-only area, 1/m
+%     'Amplitude'  [name/value]  double, flat-top amplitude, Hz/m
+%     'maxGrad'    [name/value]  double, override system.maxGrad, Hz/m
+%     'maxSlew'    [name/value]  double, override system.maxSlew, Hz/m/s
+%     'riseTime'   [name/value]  double, force rise time, seconds
+%     'fallTime'   [name/value]  double, force fall time, seconds (requires riseTime)
+%     'delay'      [name/value]  double, pre-event delay, seconds, default 0
 %
 %   OUTPUT
 %     grad  struct with fields:


### PR DESCRIPTION
A reformat PR -- no changes to the substance.

I think this structure makes more sense...the original version looked 'nice', but I would rather not have whitespace+strings randomly floating around anymore 