### PR TITLE
Document mr.calcRfBandwidth with structured help block

### DIFF
--- a/matlab/+mr/calcRfBandwidth.m
+++ b/matlab/+mr/calcRfBandwidth.m
@@ -1,10 +1,84 @@
 function [bw,fc,spectrum,f,rfs,t]=calcRfBandwidth(rf, cutoff, df, dt)
-%calcRfbandwidth Calculate the spectrum of the RF pulse
-%   Returns the bandwidth of the pulse (calculated by a simple FFT, e.g. 
-%   pesuming a low-angle approximation) and optionally the spectrum and the
-%   frequency axis. The default for the optional parameter 'cutoff' is 0.5 
-%   The default for the optional parameter 'dw' is 10 Hz. The default for 
-%   the optional parameter 'dt' is 1 us. 
+%calcRfBandwidth Compute the bandwidth and spectrum of an RF pulse.
+%
+%   PURPOSE
+%     Estimates the bandwidth of an RF pulse using a simple FFT under the
+%     low-angle (small-tip) approximation. Also returns the pulse's center
+%     frequency, complex spectrum, and the corresponding frequency and
+%     resampled time axes. Typically used for plotting excitation profile
+%     magnitude vs. frequency and for sanity-checking RF pulses produced by
+%     mr.makeSincPulse, mr.makeGaussPulse, mr.makeBlockPulse,
+%     mr.makeArbitraryRf, mr.makeSLRpulse, and mr.makeAdiabaticPulse.
+%
+%   SIGNATURES
+%     bw                            = mr.calcRfBandwidth(rf)                    % default cutoff=0.5 (FWHM), df=10 Hz, dt=1 us
+%     [bw,fc]                       = mr.calcRfBandwidth(rf)                    % also return center frequency
+%     [bw,fc,spectrum,f]            = mr.calcRfBandwidth(rf)                    % also return spectrum and frequency axis
+%     [bw,fc,spectrum,f,rfs,t]      = mr.calcRfBandwidth(rf)                    % also return resampled RF waveform and time axis
+%     [...] = mr.calcRfBandwidth(rf, cutoff)                                    % override fractional cutoff
+%     [...] = mr.calcRfBandwidth(rf, cutoff, df)                                % override spectral resolution
+%     [...] = mr.calcRfBandwidth(rf, cutoff, df, dt)                            % override time sampling step
+%
+%     Bandwidth is the frequency width at which |spectrum| drops to
+%     cutoff*max(|spectrum|), with linear interpolation at the first and
+%     last crossings. All four positional arguments must be given in order;
+%     they cannot be passed as name/value pairs.
+%
+%   INPUTS
+%     rf      [required]  struct, RF event struct from mr.makeSincPulse,
+%                         mr.makeBlockPulse, mr.makeGaussPulse, mr.makeArbitraryRf,
+%                         mr.makeSLRpulse, or mr.makeAdiabaticPulse. Must have
+%                         fields .t (seconds), .signal (complex Hz),
+%                         .freqOffset (Hz), .freqPPM, .phaseOffset (radians),
+%                         and .center (seconds).
+%     cutoff  [optional]  double, fractional threshold for bandwidth measurement,
+%                         dimensionless in (0,1]. 0.5 gives FWHM. Default: 0.5.
+%     df      [optional]  double, spectral resolution in Hz. Default: 10.
+%     dt      [optional]  double, time sampling step in seconds. Default: 1e-6.
+%
+%   OUTPUT
+%     bw        double, Hz, bandwidth at the given cutoff threshold
+%     fc        double, Hz, center frequency (midpoint of the two threshold crossings)
+%     spectrum  complex vector, small-tip excitation response, scaled by
+%                 sin(2*pi*dt*s_ref)/s_ref with s_ref = |spectrum(fc)|
+%     f         double vector, Hz, frequency axis, step df, length round(1/df/dt)
+%     rfs       complex vector, RF waveform resampled onto the uniform
+%                 time grid t, with rf.freqOffset, rf.freqPPM, and
+%                 rf.phaseOffset folded into the phase modulation
+%     t         double vector, seconds, uniform time axis centered on
+%                 rf.center, step dt, span 1/df
+%
+%   NOTES
+%     - Computed from the RF envelope's Fourier transform (small-tip
+%       equivalent). The Bloch-simulated bandwidth grows modestly at
+%       large flip angles. For exact slice-profile analysis use mr.simRf.
+%     - If rf.freqPPM is non-zero, the function calls mr.opts() to fetch
+%       sys.gamma and sys.B0 for the PPM-to-Hz conversion, and emits a
+%       warning reminding the caller to set system defaults via
+%       mr.opts('setAsDefault', true). The system defaults are used
+%       silently otherwise.
+%     - The FFT length is round(1/df/dt) (default 1e5 points). Reducing df
+%       or dt below their defaults increases compute time quadratically in
+%       the product, not in either one alone.
+%     - The spectrum is normalized so that |spectrum(fc)| approximates the
+%       on-resonance small-tip excitation amplitude rather than an
+%       unnormalized FFT magnitude.
+%
+%   EXAMPLE
+%     sys = mr.opts('MaxGrad', 30, 'GradUnit', 'mT/m', ...
+%                   'MaxSlew', 170, 'SlewUnit', 'T/m/s');
+%     rf  = mr.makeSincPulse(pi/2, 'Duration', 3e-3, ...
+%                            'SliceThickness', 3e-3, 'apodization', 0.5, ...
+%                            'timeBwProduct', 4, 'system', sys);
+%     [bw, fc, spectrum, f] = mr.calcRfBandwidth(rf);
+%     fprintf('BW = %.1f Hz, center = %.2f Hz\n', bw, fc);
+%     figure; plot(f, abs(spectrum)); xlim(3*[-bw bw]);
+%     xlabel('Frequency, Hz'); title('Excitation pulse profile');
+%
+%   SEE ALSO
+%     mr.calcRfCenter, mr.calcRfPower, mr.simRf, mr.makeSincPulse,
+%     mr.makeGaussPulse, mr.makeBlockPulse, mr.makeArbitraryRf,
+%     mr.makeSLRpulse, mr.makeAdiabaticPulse
 %
 
 if nargin<2


### PR DESCRIPTION
I kept the language of "low-angle approximation".

I completely drop [ERRORS] blocks from the structure if I can't find any explicit raised error text