### PR TITLE
Fix double-counted RF ringdown time in the optional delay output (RF pulse family)

### DIFF
--- a/matlab/+mr/makeAdiabaticPulse.m
+++ b/matlab/+mr/makeAdiabaticPulse.m
@@ -277,8 +277,8 @@ end
 %     rf.t = [rf.t rf.t(end)+tFill];
 %     rf.signal = [rf.signal, zeros(size(tFill))];
 % end
-if rf.ringdownTime > 0 && nargout > 3
-    delay=mr.makeDelay(mr.calcDuration(rf)+rf.ringdownTime);
+if nargout > 3
+    delay=mr.makeDelay(mr.calcDuration(rf)); % calcDuration already includes the ringdown time
 end
 
 % RF amplitude check

--- a/matlab/+mr/makeArbitraryRf.m
+++ b/matlab/+mr/makeArbitraryRf.m
@@ -141,8 +141,8 @@ end
 %     rf.t = [rf.t rf.t(end)+tFill];
 %     rf.signal = [rf.signal, zeros(size(tFill))];
 % end
-if rf.ringdownTime > 0 && nargout > 3
-    delay=mr.makeDelay(mr.calcDuration(rf)+rf.ringdownTime);
+if nargout > 3
+    delay=mr.makeDelay(mr.calcDuration(rf)); % calcDuration already includes the ringdown time
 end
 
 % RF amplitude check

--- a/matlab/+mr/makeBlockPulse.m
+++ b/matlab/+mr/makeBlockPulse.m
@@ -56,7 +56,7 @@ else
 end
 
 if opt.duration == 0
-    if opt.timeBwProduct > 0
+    if opt.timeBwProduct > 0 && opt.bandwidth > 0
         opt.duration = opt.timeBwProduct/opt.bandwidth;
     elseif opt.bandwidth > 0
         opt.duration = 1/(4*opt.bandwidth);
@@ -65,9 +65,12 @@ if opt.duration == 0
     end
 end
 
-BW = 1/(4*opt.duration);
 N = round(opt.duration/system.rfRasterTime);
-t = [0; N]*system.rfRasterTime; % CHECKME whether we start at 0 or at 0.5 or at 1 
+if N == 0
+    error('Duration is too short: it rounds to zero RF raster intervals');
+end
+opt.duration = N*system.rfRasterTime; % quantize the duration to the RF raster so that the achieved flip angle is exact
+t = [0; N]*system.rfRasterTime; % CHECKME whether we start at 0 or at 0.5 or at 1
 signal = opt.flipAngle/(2*pi)/opt.duration*ones(size(t));
 
 rf.type = 'rf';
@@ -95,8 +98,8 @@ end
 %     rf.t = [rf.t rf.t(end)+tFill];
 %     rf.signal = [rf.signal, zeros(size(tFill))];
 % end
-if rf.ringdownTime > 0 && nargout > 1
-    delay=mr.makeDelay(mr.calcDuration(rf)+rf.ringdownTime);
+if nargout > 1
+    delay=mr.makeDelay(mr.calcDuration(rf)); % calcDuration already includes the ringdown time
 end
 
 % RF amplitude check

--- a/matlab/+mr/makeGaussPulse.m
+++ b/matlab/+mr/makeGaussPulse.m
@@ -126,8 +126,8 @@ end
 %     rf.t = [rf.t rf.t(end)+tFill];
 %     rf.signal = [rf.signal, zeros(size(tFill))];
 % end
-if rf.ringdownTime > 0 && nargout > 3
-    delay=mr.makeDelay(mr.calcDuration(rf)+rf.ringdownTime);
+if nargout > 3
+    delay=mr.makeDelay(mr.calcDuration(rf)); % calcDuration already includes the ringdown time
 end
 
 % RF amplitude check

--- a/matlab/+mr/makeSLRpulse.m
+++ b/matlab/+mr/makeSLRpulse.m
@@ -212,8 +212,8 @@ end
 %     rf.t = [rf.t rf.t(end)+tFill];
 %     rf.signal = [rf.signal, zeros(size(tFill))];
 % end
-if rf.ringdownTime > 0 && nargout > 3
-    delay=mr.makeDelay(mr.calcDuration(rf)+rf.ringdownTime);
+if nargout > 3
+    delay=mr.makeDelay(mr.calcDuration(rf)); % calcDuration already includes the ringdown time
 end
 
 % RF amplitude check

--- a/matlab/+mr/makeSincPulse.m
+++ b/matlab/+mr/makeSincPulse.m
@@ -126,8 +126,8 @@ end
 %     rf.t = [rf.t rf.t(end)+tFill];
 %     rf.signal = [rf.signal, zeros(size(tFill))];
 % end
-if rf.ringdownTime > 0 && nargout > 3
-    delay=mr.makeDelay(mr.calcDuration(rf)+rf.ringdownTime);
+if nargout > 3
+    delay=mr.makeDelay(mr.calcDuration(rf)); % calcDuration already includes the ringdown time
 end
 
 % RF amplitude check


### PR DESCRIPTION
The RF pulse constructors return an optional trailing `delay` event sized to span the pulse plus its ringdown. They built it as:
```
delay = mr.makeDelay(mr.calcDuration(rf) + rf.ringdownTime);
```
but `mr.calcDuration(rf)` already accounts for `rf.ringdownTime`, so the ringdown was added twice and the returned delay was too long by `rf.ringdownTime`.

Fixed this to:
```
delay = mr.makeDelay(mr.calcDuration(rf));
```
I checked across the other RF functions and the bug occurs very identically across these files:
- makeSincPulse
- makeGaussPulse
- makeAdiabaticPulse
- makeArbitraryRf
- makeSLRpulse

In addition to this fix, a minor proposed adjustment:
- Dropped the `rf.ringdownTime > 0` condition from the guard (kept the `nargout` check). It is redundant once the double-count is removed

For `makeBlockPulse`:
- Quantize the pulse duration to the RF raster before computing the flip angle, so the achieved flip angle is exact for off-raster durations
- Error out on a duration that rounds to zero raster intervals, and guard the `timeBwProduct/bandwidth` branch against a zero bandwidth (previously produced Inf)