### PR TITLE
Fix center alignment, single-output duration, and invalid-spec handling in align.m

### DIFF
--- a/matlab/+mr/align.m
+++ b/matlab/+mr/align.m
@@ -9,7 +9,7 @@ function [varargout] = align(varargin)
 %   during calculating of the block duration but then reset according to 
 %   the selected alignment.
 %   Possible values for align_spec are 'left', 'center', 'right'
-%   WARNING: 'center' may break graient raster alignment
+%   WARNING: 'center' may break gradient raster alignment
 %   When a numerical parameter is passed amongst the events it is
 %   interpreted as the required duration of the block. If the duration of
 %   any of the events exceeds this required duration an error will be thrown.
@@ -27,16 +27,19 @@ if ~ischar(varargin{1})
     error('first parameter must be a string');
 end
 curr_align=find(strcmp(varargin{1},alignment_options));
+if isempty(curr_align)
+    error('invalid alignment spec');
+end
 iobjects=[];
 alignments=[];
 required_duration=[];
 
 for i=2:length(varargin)
-    if isempty(curr_align)
-        error('invalid alignment spec');
-    end
     if ischar(varargin{i})
         curr_align=find(strcmp(varargin{i},alignment_options));
+        if isempty(curr_align)
+            error('invalid alignment spec');
+        end
         continue;
     end
     if isnumeric(varargin{i})
@@ -55,7 +58,7 @@ objects={varargin{iobjects}};
 dur=mr.calcDuration(objects);
 if ~isempty(required_duration)
     if dur-required_duration>eps
-        error('Required block duration is %g s but actuall block duration is %g s', required_duration, dur);
+        error('Required block duration is %g s but actual block duration is %g s', required_duration, dur);
     end
     dur=required_duration;
 end
@@ -69,7 +72,7 @@ for i=1:length(objects)
         case 1
             objects{i}.delay=0;
         case 2
-            objects{i}.delay=(dur - mr.calcDuration(objects{i}))/2; % FIXME check how to handle the existing delay
+            objects{i}.delay=(dur - mr.calcDuration(objects{i}) + objects{i}.delay)/2;
         case 3
             ev=objects{i};
             ev_dur=mr.calcDuration(ev);
@@ -78,7 +81,7 @@ for i=1:length(objects)
             %end
             objects{i}.delay=dur - ev_dur + objects{i}.delay;
             if objects{i}.delay < 0
-                error('aligh() attempts to set a negative delay, probably some RF pulses ignore rfRingdownTime');
+                error('align() attempts to set a negative delay, probably some RF pulses ignore rfRingdownTime');
             end
     end
 end
@@ -88,13 +91,14 @@ if nargout==length(objects)
 elseif ~isempty(required_duration) && nargout==length(objects)+1
     varargout=objects;
     varargout{end+1}=required_duration;
-elseif nargout==1    
-    varargout={objects};
-    if ~isempty(required_duration)
-        varargout{end+1}=required_duration;
+elseif nargout==1
+    if isempty(required_duration)
+        varargout={objects};
+    else
+        varargout={[objects {required_duration}]};
     end
 elseif nargout<length(objects)
-    warning('not all objects can be assigned to the output argiments; we recommend using ~ to discard output arguments explicitly.');
+    warning('not all objects can be assigned to the output arguments; we recommend using ~ to discard output arguments explicitly.');
     nout=min(nargout,length(objects));
     varargout=objects(1:nout);
 else


### PR DESCRIPTION
Proposed fixes to the `align.m` file:
1. `'center'` now accounts for an event's existing delay. Centering placed the event at `(dur - calcDuration(event))/2`, ignoring any delay the event already carried (should resolve the "FIXME" :-) ). Since `calcDuration` already includes that delay, a pre-delayed event was mis-centered. Now `(dur - calcDuration(event) + event.delay)/2`. Example: centering a 1 ms gradient that carries a 0.5 ms delay in a 3 ms block now yields a 1.0 ms delay instead of 0.75 ms
2. The single-output (addBlock) form now carries the required duration. For `block = align(...)` (nargout == 1) with a numeric required-duration argument, the duration was appended as a phantom second output that a single-output caller never receives, so it was silently dropped. It is now packed into the returned cell, e.g. `align('left', g1, g2, 4e-3)` returns `{g1, g2, 4e-3}`, so `seq.addBlock(align(...){:})` honors the requested block duration
3. An invalid alignment spec now errors immediately. An unrecognized alignment string was only caught at the top of the next loop iteration, so an invalid spec in the trailing position (or with no following events) slipped through and the call returned silently. The check now runs as soon as each alignment string is parsed
4. Small typo fixes