### PR TITLE
Validate inputs in makeHexagonGradientArea.m

### DIFF
--- a/matlab/+mr/makeHexagonGradientArea.m
+++ b/matlab/+mr/makeHexagonGradientArea.m
@@ -15,6 +15,15 @@ function [grad, times, amplitudes] = makeHexagonGradientArea(channel, grad_start
         sys = default_opts(); % Define your default system
     end
 
+    % validate inputs the search below cannot handle (runaway loops or
+    % obscure downstream errors)
+    if abs(grad_start) > sys.maxGrad
+        error('grad_start amplitude violation (%.0f%%)', abs(grad_start)/sys.maxGrad*100);
+    end
+    if abs(grad_end) > sys.maxGrad
+        error('grad_end amplitude violation (%.0f%%)', abs(grad_end)/sys.maxGrad*100);
+    end
+    
     max_slew = sys.maxSlew * 0.99;
     max_grad = sys.maxGrad * 0.99;
     raster_time = sys.gradRasterTime;


### PR DESCRIPTION
`makeHexagonGradientArea` finds the shortest hexagonal gradient by growing the duration. For a few inputs that search cannot converge, and the function would spin in the doubling loop or surface a downstream error rather than reporting the problem.

So...to address this, some proposed upfront checks:
- `grad_start` amplitude above `sys.maxGrad` ---> `grad_start amplitude violation (NN%)`
- `grad_end` amplitude above `sys.maxGrad` ---> `grad_end amplitude violation (NN%)`
- `area == 0` ---> `Area must be nonzero; for a zero-area
  shape use mr.makeExtendedTrapezoid directly.`

Each bad input now errors immediately. A valid call is unaffected.