### PR TITLE
Fix componentwise-limited mode and recursion-limit leak in calcRamp

### DIFF
--- a/matlab/+mr/calcRamp.m
+++ b/matlab/+mr/calcRamp.m
@@ -81,6 +81,7 @@ MaxPoints = opt.MaxPoints;
 
 if ~mr.aux.isOctave()
   SaveRecLimit = get(0,'RecursionLimit');
+  restoreRecLimit = onCleanup(@() set(0,'RecursionLimit',SaveRecLimit));
   set(0,'RecursionLimit',MaxPoints+10);
 end
 
@@ -121,9 +122,6 @@ while (success == 0) && (UsePoints <= MaxPoints)
     UsePoints = UsePoints + 1;
 end
 
-if ~mr.aux.isOctave()
-  set(0,'RecursionLimit',SaveRecLimit);      % set previous recursion limit
-end
 
 % -------------------------------------------------------------------------
 function ok = InsideLimits(Grad,Slew)

--- a/matlab/+mr/calcRamp.m
+++ b/matlab/+mr/calcRamp.m
@@ -113,7 +113,7 @@ while (success == 0) && (UsePoints <= MaxPoints)
         end;
         kout = joinleft0(k0,kend,G0,Gend,UsePoints);
     else
-        if (abs(G0)>abs(maxGrad)) || (abs(Gend)>abs(maxGrad))
+        if any(abs(G0)>abs(maxGrad)) || any(abs(Gend)>abs(maxGrad))
             break;
         end;
         kout = joinleft1(k0,kend,G0,Gend,UsePoints);


### PR DESCRIPTION
Proposed fix for two distinct bugs in `mr.calcRamp`:
1. Componentwise-limited mode was unusable. calcRamp supports per-axis limits via `maxGrad`/`maxSlew` as `[3,1]` vectors (mode 1). The in-loop pre-check applied a scalar `||` to `[3,1]` comparisons (`(abs(G0)>abs(maxGrad)) || (abs(Gend)>abs(maxGrad))`), which raises `MATLAB:nonLogicalConditional`, so any `[3,1]` call crashed before the search started. Reduced the comparisons with `any()`. I verified that now a `[3,1]`-limit call now returns (success=1) instead of erroring
2. Root RecursionLimit leaked on an early error. calcRamp raises the root `RecursionLimit` to `MaxPoints+10` up front and previously restored it only on normal return, so an early error (e.g. an invalid maxGrad/maxSlew format) left the global limit modified for the rest of the session. Switched to `onCleanup` so it is restored on every exit path. Verified that now an erroring call previously leaving the global RecursionLimit at 510 (up from 500) now returns to 500