### PR TITLE
Fix RF shim phase reconstruction in getBlock

### DIFF
--- a/matlab/+mr/@Sequence/Sequence.m
+++ b/matlab/+mr/@Sequence/Sequence.m
@@ -1288,9 +1288,9 @@ classdef Sequence < handle
                     end
                     data = obj.rfShimLibrary.data(rf_shim_ext(2,1)).array;
                     if addIDs
-                        block.rfShim=struct('type','rfShim','shimVector',data(1:2:end).*exp(1i*2*pi*data(2:2:end)),'id',rf_shim_ext(2,1));
+                        block.rfShim=struct('type','rfShim','shimVector',data(1:2:end).*exp(1i*data(2:2:end)),'id',rf_shim_ext(2,1));
                     else
-                        block.rfShim=struct('type','rfShim','shimVector',data(1:2:end).*exp(1i*2*pi*data(2:2:end)));
+                        block.rfShim=struct('type','rfShim','shimVector',data(1:2:end).*exp(1i*data(2:2:end)));
                     end
                 end
                 % unpack 3D rotations


### PR DESCRIPTION
This is a low-stakes correctness bug, not super-relevant to the current Pulseq framework behavior...but the bug could surface in the future depending on what capabilities are added or what Pulseq integrates with.

The RF_SHIMS extension stores shim phases in radians -- `registerRfShimEvent` writes them with `angle()` (Sequence.m:792). `getBlock`, however, rebuilt the complex shim weights as `exp(1i*2*pi*phase)`, treating the stored radians as cycles. So  `shimVector` returned by getBlock had distorted phases after either an addBlock--->getBlock or a write--->read--->getBlock round trip, even though the write path itself was correct.

Proposed fix: reconstruct as `exp(1i*phase)`.

Verified with round-trip tests: a shim weight of `exp(i*pi/2)` came back with phase -2.6968 rad (should be 1.5708) before the fix. After it, both addBlock/getBlock and write/read/getBlock round-trips recover the phases exactly (max abs error 0 and ~1e-7 respectively).