### PR TITLE
Support zero-area requests in the gradient-area constructors

### DIFF
--- a/matlab/+mr/makeExtendedTrapezoidArea.m
+++ b/matlab/+mr/makeExtendedTrapezoidArea.m
@@ -87,6 +87,16 @@ end
 
 function sol = find_solution(duration, area, grad_start, grad_end, max_slew, max_grad, raster_time)
     sign_area = sign(area);
+    if sign_area == 0
+        % zero-area request (e.g. linking two trajectory segments without
+        % changing the k-space position): sign(0) would zero out the search
+        % direction and produce Inf ranges in the flat=0 estimates below, so
+        % search on the side opposite to the edge gradients instead
+        sign_area = -sign(grad_start + grad_end);
+        if sign_area == 0
+            sign_area = 1;
+        end
+    end
     grad_amp = sign_area * max_grad;
 
     % Convert to raster steps

--- a/matlab/+mr/makeHexagonGradientArea.m
+++ b/matlab/+mr/makeHexagonGradientArea.m
@@ -48,10 +48,11 @@ function [grad, times, amplitudes] = makeHexagonGradientArea(channel, grad_start
         [times, amplitudes] = binary_search(@(d) find_solution(d, area, grad_start, grad_end, max_slew, max_grad, raster_time), ...
                                  floor(duration/2), duration);
     end
-    if any(diff(times) == 0)
-        times = [times(1), times(2), times(4)];
-        amplitudes = [amplitudes(1), amplitudes(2), amplitudes(4)];
-    end
+    % drop zero-length segments (their end points always carry equal
+    % amplitudes, otherwise the slew-rate check would have rejected them)
+    keep = [true, diff(times) > 0];
+    times = times(keep);
+    amplitudes = amplitudes(keep);
     grad=mr.makeExtendedTrapezoid(channel,'system',sys,'times',times, 'amplitudes', amplitudes);
     if abs(grad.area - area) >= 1e-3
         error('Could not find a solution for area=%.6f.', area);
@@ -84,6 +85,16 @@ function [times, amplitudes] = find_solution(duration, area, grad_start, grad_en
 % Find extended trapezoid gradient waveform for given duration
 
     sign_area = sign(area);
+    if sign_area == 0
+        % zero-area request (e.g. linking two trajectory segments without
+        % changing the k-space position): sign(0) would zero out the search
+        % direction and send the loops below into runaway iterations, so
+        % search on the side opposite to the edge gradients instead
+        sign_area = -sign(grad_start + grad_end);
+        if sign_area == 0
+            sign_area = 1;
+        end
+    end
     grad_amp = sign_area * max_grad;
     ramp_up_times = [];
     ramp_down_times = [];

--- a/tests/testMakeHexagonGradientArea.m
+++ b/tests/testMakeHexagonGradientArea.m
@@ -141,7 +141,7 @@ end
 function test_case_12_nearmax_small_area(tc)
     sys = defaultSys();
     g = sys.maxGrad * 0.8;
-    channel = 'y'; g_start = g; g_end = g; area = 500; %0 fails!
+    channel = 'y'; g_start = g; g_end = g; area = 500;
 
     [grad_trap, ~, ~] = mr.makeExtendedTrapezoidArea(channel, ...
         g_start, g_end, area, sys);
@@ -157,6 +157,39 @@ function test_case_12_nearmax_small_area(tc)
     % Log durations for information (hexagon may be longer here)
     fprintf('  near-max case: trap=%.6f s  hex=%.6f s\n', ...
         grad_trap.shape_dur, grad_hex.shape_dur);
+end
+
+%% Test: zero area, equal nonzero edges (link two trajectory segments)
+function test_case_13_zero_area_equal_edges(tc)
+    sys = defaultSys();
+    g = sys.maxGrad * 0.3;
+    run_case(tc, 'x', g, g, 0);
+end
+
+%% Test: zero area, antisymmetric edges (straight-ramp solution)
+function test_case_14_zero_area_antisym_edges(tc)
+    sys = defaultSys();
+    g = sys.maxGrad * 0.3;
+    run_case(tc, 'y', g, -g, 0);
+end
+
+%% Test: zero area, nonzero start, zero end
+function test_case_15_zero_area_onesided(tc)
+    sys = defaultSys();
+    run_case(tc, 'z', sys.maxGrad*0.3, 0, 0);
+end
+
+%% Test: zero area, unequal negative edges
+function test_case_16_zero_area_unequal_edges(tc)
+    sys = defaultSys();
+    run_case(tc, 'x', -sys.maxGrad*0.3, -sys.maxGrad*0.075, 0);
+end
+
+%% Test: zero area, near-max edges (regime of test_case_12)
+function test_case_17_zero_area_nearmax_edges(tc)
+    sys = defaultSys();
+    g = sys.maxGrad * 0.8;
+    run_case(tc, 'y', g, g, 0);
 end
 
 % =====================================================================


### PR DESCRIPTION
Separate PR to address PR #267 review (area=0 with nonzero edge gradients are valid asks)

Current behavior:
- mr.makeHexagonGradientArea hangs
- mr.makeExtendedTrapezoidArea (from which the hexagon was derived) errors for equal nonzero edges

These issues are able to reproduced as follows:
```
sys = mr.opts('MaxGrad', 30, 'GradUnit', 'mT/m', 'MaxSlew', 150, 'SlewUnit', 'T/m/s');
g = 0.3*sys.maxGrad;
mr.makeHexagonGradientArea('x', g, g, 0, sys);        % hangs
mr.makeExtendedTrapezoidArea('x', g, g, 0, sys);      % array-size error
```

Proposed fix, applied to both find_solution implementations:
- when `sign(area)` is 0, take the search direction opposite the edge gradients, `-sign(grad_start + grad_end)`, falling back to +1 when that is also zero (there the straight ramp already has zero area). The direct ramp's area is proportional to (grad_start + grad_end)/2, so the correcting lobe must oppose it.

Also, the hexagon needs its duplicate-time cleanup generalized. A solution to antisymmetric edges (like +g ---> -g, area 0) would be a pure ramp (check my logic please), which would collapse **two** segments to zero length. So, all zero-length segments are now removed.

This PR also adds five zero-area test cases. All pre-existing cases return unchanged results. 